### PR TITLE
ci: move codecov secret to level agnostic location

### DIFF
--- a/taskcluster/ci/codecov/kind.yml
+++ b/taskcluster/ci/codecov/kind.yml
@@ -22,7 +22,7 @@ tasks:
             env:
                 MOZ_FETCHES_DIR: /builds/worker/fetches
         scopes:
-            - secrets:get:project/releng/taskgraph/mozilla-taskgraph/build/level-1/codecov
+            - secrets:get:project/releng/taskgraph/mozilla-taskgraph/ci
         dependencies:
             test: test-unit
         fetches:

--- a/taskcluster/scripts/codecov-upload.py
+++ b/taskcluster/scripts/codecov-upload.py
@@ -20,9 +20,9 @@ def fetch_secret(secret_name):
     return r.json()["secret"]
 
 
-token = fetch_secret(
-    "project/releng/taskgraph/mozilla-taskgraph/build/level-1/codecov"
-)["token"]
+token = fetch_secret("project/releng/taskgraph/mozilla-taskgraph/ci")[
+    "codecov_api_token"
+]
 uploader = FETCHES_DIR / "codecov"
 uploader.chmod(uploader.stat().st_mode | stat.S_IEXEC)
 subprocess.run(


### PR DESCRIPTION
This secret is used both on-push (level 3) and trusted pull requests (level 1). So we shouldn't put it in a level specific location.