### PR TITLE
ci: fix possibility of multiple switch arms evaluating to true in tc.yml

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -41,7 +41,7 @@ tasks:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
                   'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
-                  'tasks_for == "github-push"': ${event.ref}
+                  'tasks_for == "github-push" && !event.base_ref': ${event.ref}
                   'tasks_for in ["cron", "action"]': '${push.branch}'
           head_ref:
               $switch:


### PR DESCRIPTION
Turns out the two middle arms are true when creating Github Release events, and Taskcluster complains via comment when this happens.