### PR TITLE
ci: fix syntax error in .taskcluster.yml

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -41,7 +41,7 @@ tasks:
               $switch:
                   'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
                   'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
-                  'tasks_for == "github-push" && !event.base_ref': ${event.ref}
+                  'tasks_for == "github-push" && !(event.base_ref)': ${event.ref}
                   'tasks_for in ["cron", "action"]': '${push.branch}'
           head_ref:
               $switch:


### PR DESCRIPTION
After playing around with this in the JSON-e playground, the problem is that this needs brackets.