### PR TITLE
feat: use 'scriptworker.scope-prefix' config for mark-as-shipped

### DIFF
--- a/src/mozilla_taskgraph/transforms/scriptworker/shipit/mark_as_shipped.py
+++ b/src/mozilla_taskgraph/transforms/scriptworker/shipit/mark_as_shipped.py
@@ -42,10 +42,16 @@ def make_task_description(config, tasks):
     if "shipit" in config.graph_config:
         shipit = config.graph_config["shipit"]
 
+    scriptworker = {}
+    if "scriptworker" in config.graph_config:
+        scriptworker = config.graph_config["scriptworker"]
+
     release_format = shipit.get(
         "release-format", "{product}-{version}-build{build_number}"
     )
-    scope_prefix = shipit.get("scope-prefix", "project:releng:ship-it")
+    scope_prefix = shipit.get(
+        "scope-prefix", f"{scriptworker.get('scope-prefix', 'project:releng')}:ship-it"
+    )
     shipit_server = "production" if config.params["level"] == "3" else "staging"
     version = config.params.get("version", "<ver>")
 

--- a/test/transforms/test_scriptworker_shipit.py
+++ b/test/transforms/test_scriptworker_shipit.py
@@ -40,10 +40,17 @@ def assert_release_format(task):
     assert task["worker"]["release-name"] == "release-app-v1.2.3-b10"
 
 
-def assert_scope_prefix(task):
+def assert_scope_prefix_shipit(task):
     assert task["scopes"] == [
         "project:app:releng:action:mark-as-shipped",
         "project:app:releng:server:staging",
+    ]
+
+
+def assert_scope_prefix_scriptworker(task):
+    assert task["scopes"] == [
+        "project:app:releng:ship-it:action:mark-as-shipped",
+        "project:app:releng:ship-it:server:staging",
     ]
 
 
@@ -103,7 +110,16 @@ def assert_product_in_task_keyed_by(task):
             {"shipit": {"product": "app", "scope-prefix": "project:app:releng"}},
             {"level": "1"},
             {},
-            id="scope_prefix",
+            id="scope_prefix_shipit",
+        ),
+        pytest.param(
+            {
+                "shipit": {"product": "app"},
+                "scriptworker": {"scope-prefix": "project:app:releng"},
+            },
+            {"level": "1"},
+            {},
+            id="scope_prefix_scriptworker",
         ),
         pytest.param(
             {},


### PR DESCRIPTION
Currently we look at a `shipit.scope-prefix` config to get the scope prefix. However, `scriptworker.scope-prefix` is already a standard.

This implements the ability to use that config in a backwards compatible manner. I.e, it will first check the `shipit` config, then the `scriptworker` one if none was found.