### PR TITLE
chore: add missing 'readme' entry to project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "mozilla-taskgraph"
 version = "3.0.0"
 description = "Mozilla specific transforms and utilities for Taskgraph"
+readme = "README.md"
 authors = [
   { name = "Mozilla Release Engineering", email =  "release+mozilla-taskgraph@mozilla.com"}
 ]


### PR DESCRIPTION
This was causing errors with twine during the publishs step.