### PR TITLE
Replace the pre-commit.ci app with github workflows

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,15 @@
+name: Autoupdate
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+jobs:
+  pre-commit:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: mozilla-releng/actions/pre-commit-autoupdate@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,12 @@
+---
+name: "Pre-commit"
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  pre-commit:
+    name: Run pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mozilla-releng/actions/pre-commit@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 ---
 ci:
-  autofix_commit_msg: "style: pre-commit.ci auto fixes [...]"
   autoupdate_commit_msg: "chore: pre-commit autoupdate"
-  autoupdate_schedule: monthly
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/uv.lock
+++ b/uv.lock
@@ -567,7 +567,7 @@ wheels = [
 
 [[package]]
 name = "mozilla-taskgraph"
-version = "3.0.3"
+version = "3.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "taskcluster-taskgraph" },


### PR DESCRIPTION
Since we're using the uv hook, pre-commit requires the internet to work properly which the pre-commit.ci app ran jobs don't have access to. These two workflows are meant to replace the app entirely by doing both checking on PRs/main and auto updates. It means that we do lose the autofix feature, but it's that or throwing away the uv-lock hook.

Original work done in https://github.com/taskcluster/taskgraph/pull/677 and https://github.com/taskcluster/taskgraph/pull/678