### PR TITLE
fix: stop adding format scopes in scriptworker-signing payload builder

### DIFF
--- a/src/mozilla_taskgraph/worker_types.py
+++ b/src/mozilla_taskgraph/worker_types.py
@@ -169,7 +169,6 @@ def build_signing_payload(config, task, task_def):
     scope_prefix = config.graph_config["scriptworker"]["scope-prefix"]
     scopes = set(task_def.get("scopes", []))
     scopes.add(f"{scope_prefix}:signing:cert:{worker['signing-type']}")
-    scopes.update({f"{scope_prefix}:signing:format:{format}" for format in formats})
 
     task_def["scopes"] = sorted(scopes)
 

--- a/test/test_worker_types.py
+++ b/test/test_worker_types.py
@@ -382,7 +382,6 @@ def test_build_signing_payload_basic(build_payload):
         },
         "scopes": [
             "foo:signing:cert:release",
-            "foo:signing:format:gpg",
         ],
         "tags": {"worker-implementation": "scriptworker"},
     }
@@ -421,7 +420,6 @@ def test_build_signing_payload_dmg(build_payload):
         },
         "scopes": [
             "foo:signing:cert:release",
-            "foo:signing:format:gpg",
         ],
         "tags": {"worker-implementation": "scriptworker"},
     }
@@ -456,7 +454,6 @@ def test_build_signing_payload_gpg_asc(build_payload):
         },
         "scopes": [
             "foo:signing:cert:release",
-            "foo:signing:format:gcp_prod_autograph_gpg",
         ],
         "tags": {"worker-implementation": "scriptworker"},
     }


### PR DESCRIPTION
These scopes aren't actually validated in signingscript and we decided to drop them from task definitions.