### PR TITLE
fix: allow taskref's in upload data destinations

### DIFF
--- a/src/mozilla_taskgraph/worker_types.py
+++ b/src/mozilla_taskgraph/worker_types.py
@@ -478,7 +478,7 @@ def dash_to_underscore(obj):
             {
                 Required("data"): str,
                 Required("content-type"): str,
-                Required("destinations"): [str],
+                Required("destinations"): [taskref_or_string],
             },
         ],
         Optional("dry-run"): bool,

--- a/test/test_worker_types.py
+++ b/test/test_worker_types.py
@@ -1129,6 +1129,7 @@ def test_beetmover_upload_data(build_payload):
                 "destinations": [
                     "foo.txt",
                     "bar.txt",
+                    {"task-reference": "<foo>"},
                 ],
             },
         ],
@@ -1146,6 +1147,7 @@ def test_beetmover_upload_data(build_payload):
                     "destinations": [
                         "foo.txt",
                         "bar.txt",
+                        {"task-reference": "<foo>"},
                     ],
                 },
             ],


### PR DESCRIPTION
I realized shortly after merging #102 that this is needed :(