### PR TITLE
chore: allow taskcluster-taskgraph 15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.4.1 (2025-08-13)
+
+## Added
+
+- mark as compatible with taskcluster-taskgraph 15
+
 ## 3.4.0 (2025-07-15)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mozilla-taskgraph"
-version = "3.4.0"
+version = "3.4.1"
 description = "Mozilla specific transforms and utilities for Taskgraph"
 readme = "README.md"
 authors = [
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "taskcluster-taskgraph>=11,<15",
+  "taskcluster-taskgraph>=11,<16",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -567,7 +567,7 @@ wheels = [
 
 [[package]]
 name = "mozilla-taskgraph"
-version = "3.4.0"
+version = "3.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "taskcluster-taskgraph" },
@@ -590,7 +590,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "taskcluster-taskgraph", specifier = ">=11,<15" }]
+requires-dist = [{ name = "taskcluster-taskgraph", specifier = ">=11,<16" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This just recently major version is fully compatible with mozilla-taskgraph.