### PR TITLE
chore(renovate): ensure renovate only ever widens dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>mozilla-releng/reps:renovate-preset.json5"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["project.dependencies"],
+      "rangeStrategy": "widen"
+    }
   ]
 }


### PR DESCRIPTION
`mozilla-taskgraph` is a library so we should leave the lower bounds alone unless an update is actually required.