### PR TITLE
Bug 2037926 - generate file-specific version_bump scopes for landoscript

### DIFF
--- a/src/mozilla_taskgraph/worker_types.py
+++ b/src/mozilla_taskgraph/worker_types.py
@@ -335,6 +335,7 @@ def build_lando_payload(config, task, task_def):
     if worker.get("force-dry-run"):
         task_def["payload"]["dry_run"] = True
 
+    bump_files: list[str] = []
     for action in worker["actions"]:
         if info := action.get("android-l10n-import"):
             android_l10n_import_info = dash_to_underscore(info)
@@ -384,6 +385,7 @@ def build_lando_payload(config, task, task_def):
             bump_info = {}
             bump_info["next_version"] = release_config["next_version"]
             bump_info["files"] = info["bump-files"]
+            bump_files = info["bump-files"]
             task_def["payload"]["version_bump_info"] = bump_info
             actions.append("version_bump")
 
@@ -423,7 +425,13 @@ def build_lando_payload(config, task, task_def):
 
     scopes = set(task_def.get("scopes", []))
     scopes.add(f"project:releng:lando:repo:{worker['lando-repo']}")
-    scopes.update([f"project:releng:lando:action:{action}" for action in actions])
+    scopes.update(
+        f"project:releng:lando:action:{a}" for a in actions if a != "version_bump"
+    )
+    if "version_bump" in actions:
+        scopes.update(
+            f"project:releng:lando:action:version_bump:file:{f}" for f in bump_files
+        )
 
     for matrix_room in worker.get("matrix-rooms", []):
         task_def.setdefault("routes", [])

--- a/test/test_worker_types.py
+++ b/test/test_worker_types.py
@@ -750,7 +750,8 @@ def test_lando_version_bump(build_payload):
             },
         },
         "scopes": [
-            "project:releng:lando:action:version_bump",
+            "project:releng:lando:action:version_bump:file:another/file.txt",
+            "project:releng:lando:action:version_bump:file:foo/bar/a.txt",
             "project:releng:lando:repo:testrepo",
         ],
         "tags": {"worker-implementation": "scriptworker"},


### PR DESCRIPTION
## Summary

- `build_lando_payload`: replaces `project:releng:lando:action:version_bump` with `project:releng:lando:action:version_bump:file:<path>` for each file in `bump-files`
- All other lando action scopes are unchanged
- Updates `test_lando_version_bump` to expect the new file-specific scope format

## Merge order

1. [fxci-config staging #1012](https://github.com/mozilla-releng/fxci-config/pull/1012) — apply-staging + merge **first**
2. [scriptworker-scripts #1448](https://github.com/mozilla-releng/scriptworker-scripts/pull/1448) — deploy to staging, merge
3. [fxci-config production #1038](https://github.com/mozilla-releng/fxci-config/pull/1038) — after staging verification
4. This PR — merge + publish new version
5. xpi-manifest — update mozilla-taskgraph pin, trigger staging e2e test
6. firefox gecko_taskgraph — Phabricator + uplift
7. fxci-config cleanup (separate PR) — remove old general `version_bump` grants
8. scriptworker-scripts cleanup (separate PR) — remove transition fallback from `validate_scopes`

## Verification

All 69 unit tests pass:
```
uv run pytest test/ -v
```

Taskgraph validation in xpi-manifest (using `--with-editable`) confirms the `version-bump-newtab` task scopes are now:
```json
[
  "project:releng:lando:action:version_bump:file:browser/extensions/newtab/manifest.json",
  "project:releng:lando:repo:firefox-main"
]
```

[Bug 2037926](https://bugzilla.mozilla.org/show_bug.cgi?id=2037926)