### PR TITLE
Bug 2050679 - feat: add copy_attributes_from_dependent_job utility

### DIFF
--- a/src/mozilla_taskgraph/util/attributes.py
+++ b/src/mozilla_taskgraph/util/attributes.py
@@ -4,6 +4,38 @@
 
 import re
 
+_COPYABLE_ATTRIBUTES = (
+    "accepted-mar-channel-ids",
+    "artifact_map",
+    "artifact_prefix",
+    "build_platform",
+    "build_type",
+    "l10n_chunk",
+    "locale",
+    "mar-channel-id",
+    "maven_packages",
+    "nightly",
+    "shippable",
+    "shipping_phase",
+    "shipping_product",
+    "signed",
+    "stub-installer",
+    "update-channel",
+)
+
+
+def copy_attributes_from_dependent_job(dep_job, denylist=()):
+    """Copy the curated ``_COPYABLE_ATTRIBUTES`` from a dependent job.
+
+    Only attributes present on ``dep_job`` and not in ``denylist`` are copied,
+    so entries that don't apply to a given job are simply skipped.
+    """
+    return {
+        attr: dep_job.attributes[attr]
+        for attr in _COPYABLE_ATTRIBUTES
+        if attr in dep_job.attributes and attr not in denylist
+    }
+
 
 def release_level(release_branches: dict, params: dict):
     """Whether this is a production release or not.

--- a/test/util/test_attributes.py
+++ b/test/util/test_attributes.py
@@ -2,9 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from types import SimpleNamespace
+
 import pytest
 
-from mozilla_taskgraph.util.attributes import release_level
+from mozilla_taskgraph.util.attributes import (
+    copy_attributes_from_dependent_job,
+    release_level,
+)
 
 FIREFOX_BRANCHES = ["main", "beta", "release", "esr140"]
 RELEASE_BRANCHES = {
@@ -54,3 +59,23 @@ RELEASE_BRANCHES = {
 )
 def test_release_level(release_branches, params, expected):
     assert release_level(release_branches, params) == expected
+
+
+def test_copy_attributes_from_dependent_job():
+    dep_job = SimpleNamespace(
+        attributes={
+            "build_platform": "linux64",
+            "shippable": True,
+            "locale": "de",
+            "not_copyable": "x",  # not in _COPYABLE_ATTRIBUTES -> skipped
+        }
+    )
+    assert copy_attributes_from_dependent_job(dep_job) == {
+        "build_platform": "linux64",
+        "shippable": True,
+        "locale": "de",
+    }
+    assert copy_attributes_from_dependent_job(dep_job, denylist=("locale",)) == {
+        "build_platform": "linux64",
+        "shippable": True,
+    }


### PR DESCRIPTION
Add copy_attributes_from_dependent_job and its `_COPYABLE_ATTRIBUTES` allowlist, which inherit a curated set of release/build attributes from a dependent job. Only attributes present on the dependent job and not in the caller-supplied denylist are copied, so entries that don't apply to a given job are skipped.

This logic currently lives in gecko_taskgraph; moving it here lets gecko and comm share a single implementation.

### Why only copy_attributes_from_dependent_job?

`gecko_taskgraph.util.attributes` has several functions, but IMO they don't all belong here. `mozilla-taskgraph` is for logic that's generic across Mozilla projects and actually shared between them. This function fits: both `gecko` and `comm` use it, so a single shared implementation makes sense.

The rest are intentionally left out:

- Project-specific data — I think the project lists, release branches, run-on-project aliases and `match_run_on_projects` function are Firefox/Thunderbird-specific, so they stay in each project's own taskgraph, not a shared package. Let me know if you agree on this.

- Fully generic helpers (`task_name`, `match_run_on_hg_branches`) — since these don't seem to be Mozilla-specific at all, should we move them to upstream `Taskgraph` instead? It appears that taskgraph attributes.py has a sibling [match_run_on_git_branches](https://github.com/taskcluster/taskgraph/blob/main/src/taskgraph/util/attributes.py#L78) already.

- Already upstream / unused — a couple (`match_run_on_repo_type`, `sorted_unique_list`) are already thin wrappers around upstream code or have no callers, so they're cleanup in gecko rather than something to move.
