### PR TITLE
feat: bug 2055645: add support for direct git tags in landoscript payloads (BREAKING CHANGE)

### DIFF
--- a/src/mozilla_taskgraph/worker_types.py
+++ b/src/mozilla_taskgraph/worker_types.py
@@ -237,7 +237,8 @@ class L10nBumpInfo(Schema):
 
 class TagConfig(Schema):
     types: list[Literal["buildN", "release"]]
-    hg_repo_url: str
+    revision: str
+    hg_repo_url: Optional[str]
 
 
 class VersionBumpConfig(Schema):
@@ -379,11 +380,11 @@ def build_lando_payload(config, task, task_def):
                 tag_names.extend([f"{product}_{version}_RELEASE"])
             tag_info = {
                 "tags": tag_names,
-                "hg_repo_url": info["hg-repo-url"],
-                "revision": config.params[
-                    "{}head_rev".format(worker.get("repo-param-prefix", ""))
-                ],
+                "revision": info["revision"],
             }
+            if repo_url := info.get("hg-repo-url"):
+                tag_info["hg_repo_url"] = repo_url
+
             task_def["payload"]["tag_info"] = tag_info
             actions.append("tag")
 

--- a/test/test_worker_types.py
+++ b/test/test_worker_types.py
@@ -675,45 +675,72 @@ def test_lando_l10n_bump(build_payload):
 
 
 @pytest.mark.parametrize(
-    "types,expected",
+    "hg_repo_url,revision,types,expected",
     (
         pytest.param(
+            "https://hg/repo",
+            "abcdefghi",
             ["buildN"],
             ["PRODUCT_99_0_BUILD1"],
-            id="buildN",
+            id="hg_buildN",
         ),
         pytest.param(
+            "https://hg/repo",
+            "abcdefghi",
             ["release"],
             ["PRODUCT_99_0_RELEASE"],
-            id="release",
+            id="hg_release",
         ),
         pytest.param(
+            "https://hg/repo",
+            "abcdefghi",
             ["buildN", "release"],
             ["PRODUCT_99_0_BUILD1", "PRODUCT_99_0_RELEASE"],
-            id="buildN_and_release",
+            id="hg_buildN_and_release",
+        ),
+        pytest.param(
+            None,
+            "abcdefghi",
+            ["buildN"],
+            ["PRODUCT_99_0_BUILD1"],
+            id="git_buildN",
+        ),
+        pytest.param(
+            None,
+            "abcdefghi",
+            ["release"],
+            ["PRODUCT_99_0_RELEASE"],
+            id="git_release",
+        ),
+        pytest.param(
+            None,
+            "abcdefghi",
+            ["buildN", "release"],
+            ["PRODUCT_99_0_BUILD1", "PRODUCT_99_0_RELEASE"],
+            id="git_buildN_and_release",
         ),
     ),
 )
-def test_lando_tag(build_payload, types, expected):
+def test_lando_tag(build_payload, hg_repo_url, revision, types, expected):
     worker = {
         "lando-repo": "testrepo",
         "actions": [
             {
                 "tag": {
                     "types": types,
-                    "hg-repo-url": "https://hg/repo",
+                    "hg-repo-url": hg_repo_url,
+                    "revision": revision,
                 }
             }
         ],
     }
     _, task_def = build_payload("scriptworker-lando", worker=worker)
-    assert task_def == {
+    expected = {
         "payload": {
             "actions": ["tag"],
             "lando_repo": "testrepo",
             "tag_info": {
-                "hg_repo_url": "https://hg/repo",
-                "revision": "abcdef",
+                "revision": revision,
                 "tags": expected,
             },
         },
@@ -723,6 +750,10 @@ def test_lando_tag(build_payload, types, expected):
         ],
         "tags": {"worker-implementation": "scriptworker"},
     }
+    if hg_repo_url:
+        expected["payload"]["tag_info"]["hg_repo_url"] = hg_repo_url
+
+    assert task_def == expected
 
 
 def test_lando_version_bump(build_payload):


### PR DESCRIPTION
Note that this gets rid of the automatic lookup of revision and requires it to be present in the `worker` action instead. This is not _strictly_ necessary (we could, theoretically, stuff the git revision into parameters and have the payload builder look it up), but IMO the payload builders should avoid digging into parameters whenever possible in the first place. This makes this work a breaking change, and will require adjustments on the Gecko side to provide a git or hg revision, and the `hg_repo_url` when appropriate.

See https://github.com/mozilla-releng/scriptworker-scripts/pull/1491 for the landoscript side of this, which is required before this is merged.